### PR TITLE
Add cloudbuild files for building buildpack images

### DIFF
--- a/builder/builder.toml
+++ b/builder/builder.toml
@@ -74,5 +74,5 @@ group = [
 
 [stack]
 id = "io.buildpacks.stacks.bionic"
-run-image = "REPLACE_WITH_REGISTRY/run:latest"
-build-image = "REPLACE_WITH_REGISTRY/build:latest"
+run-image = "${REPLACE_WITH_REGISTRY}/run:latest"
+build-image = "${REPLACE_WITH_REGISTRY}/build:latest"

--- a/cloudbuild.promote.yaml
+++ b/cloudbuild.promote.yaml
@@ -1,0 +1,117 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This build configuration is used to promote images by changing image suffixes.
+substitutions:
+  _FROM_SUFFIX: -edge
+  _TO_SUFFIX: ""
+
+steps:
+
+# base
+- id: base-pull
+  name: gcr.io/cloud-builders/docker
+  args:
+  - pull
+  - gcr.io/${PROJECT_ID}/base${_FROM_SUFFIX}
+  waitFor:
+  - "-"
+- id: base-tag
+  name: gcr.io/cloud-builders/docker
+  args:
+  - tag
+  - gcr.io/${PROJECT_ID}/base${_FROM_SUFFIX}
+  - gcr.io/${PROJECT_ID}/base${_TO_SUFFIX}
+  waitFor:
+  - base-pull
+- id: base-push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/base${_TO_SUFFIX}
+  waitFor:
+  - base-tag
+
+# build
+- id: build-pull
+  name: gcr.io/cloud-builders/docker
+  args:
+  - pull
+  - gcr.io/${PROJECT_ID}/build${_FROM_SUFFIX}
+  waitFor:
+  - "-"
+- id: build-tag
+  name: gcr.io/cloud-builders/docker
+  args:
+  - tag
+  - gcr.io/${PROJECT_ID}/build${_FROM_SUFFIX}
+  - gcr.io/${PROJECT_ID}/build${_TO_SUFFIX}
+  waitFor:
+  - build-pull
+- id: build-push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/build${_TO_SUFFIX}
+  waitFor:
+  - build-tag
+
+# run
+- id: run-pull
+  name: gcr.io/cloud-builders/docker
+  args:
+  - pull
+  - gcr.io/${PROJECT_ID}/run${_FROM_SUFFIX}
+  waitFor:
+  - "-"
+- id: run-tag
+  name: gcr.io/cloud-builders/docker
+  args:
+  - tag
+  - gcr.io/${PROJECT_ID}/run${_FROM_SUFFIX}
+  - gcr.io/${PROJECT_ID}/run${_TO_SUFFIX}
+  waitFor:
+  - run-pull
+- id: run-push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/run${_TO_SUFFIX}
+  waitFor:
+  - run-tag
+
+# buildpack-builder
+- id: buildpack-builder-pull
+  name: gcr.io/cloud-builders/docker
+  args:
+  - pull
+  - gcr.io/${PROJECT_ID}/buildpack-builder${_FROM_SUFFIX}
+  waitFor:
+  - "-"
+- id: buildpack-builder-tag
+  name: gcr.io/cloud-builders/docker
+  args:
+  - tag
+  - gcr.io/${PROJECT_ID}/buildpack-builder${_FROM_SUFFIX}
+  - gcr.io/${PROJECT_ID}/buildpack-builder${_TO_SUFFIX}
+  waitFor:
+  - buildpack-builder-pull
+- id: buildpack-builder-push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/buildpack-builder${_TO_SUFFIX}
+  waitFor:
+  - buildpack-builder-tag
+

--- a/cloudbuild.tools.yaml
+++ b/cloudbuild.tools.yaml
@@ -1,0 +1,44 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This build config builds container images used in cloudbuild.yaml
+
+steps:
+- id: get
+  name: 'tutum/curl' # ubuntu + curl
+  args:
+    - bash
+    - -exc
+    - |
+      curl -Lo master.tar.gz https://github.com/GoogleCloudPlatform/cloud-builders-community/archive/master.tar.gz
+      tar xfz master.tar.gz
+- id: docker-build-pack
+  name: 'gcr.io/cloud-builders/docker'
+  args:
+  - build
+  - --tag=gcr.io/${PROJECT_ID}/pack
+  - cloud-builders-community-master/pack
+  waitFor:
+  - get
+- id: docker-build-envsubst
+  name: 'gcr.io/cloud-builders/docker'
+  args:
+  - build
+  - --tag=gcr.io/${PROJECT_ID}/envsubst
+  - cloud-builders-community-master/envsubst
+  waitFor:
+  - get
+images:
+- gcr.io/${PROJECT_ID}/pack
+- gcr.io/${PROJECT_ID}/envsubst

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,99 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This build configuration builds the buildpack-builder image and the runtime
+# images used for building/running buildpack apps.
+
+# The cloudbuild.tools.yaml build config is a prerequisite to this build config,
+# as images from that config are dependencies in this one.
+
+substitutions:
+  _IMAGE_SUFFIX: -edge
+
+steps:
+- id: base
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --tag=gcr.io/${PROJECT_ID}/base${_IMAGE_SUFFIX}
+  - stacks/bionic/base
+
+- id: base-push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/base${_IMAGE_SUFFIX}
+  waitFor:
+  - base
+
+- id: build
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --build-arg
+  - base_image=gcr.io/${PROJECT_ID}/base${_IMAGE_SUFFIX}
+  - --tag=gcr.io/${PROJECT_ID}/build${_IMAGE_SUFFIX}
+  - stacks/bionic/build
+  waitFor:
+  - base-push
+
+- id: build-push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/build${_IMAGE_SUFFIX}
+  waitFor:
+  - build
+
+- id: run
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --build-arg
+  - base_image=gcr.io/${PROJECT_ID}/base${_IMAGE_SUFFIX}
+  - --tag=gcr.io/${PROJECT_ID}/run${_IMAGE_SUFFIX}
+  - stacks/bionic/run
+  waitFor:
+  - base-push
+
+- id: run-push
+  name: gcr.io/cloud-builders/docker
+  args:
+  - push
+  - gcr.io/${PROJECT_ID}/run${_IMAGE_SUFFIX}
+  waitFor:
+  - run
+
+- id: preprocess-builder-image
+  name: gcr.io/${PROJECT_ID}/envsubst
+  env:
+  - REPLACE_WITH_REGISTRY=gcr.io/${PROJECT_ID}
+  args:
+  - builder/builder.toml
+  waitFor:
+  - '-' # wait for no-one
+
+- id: builder
+  name: gcr.io/${PROJECT_ID}/pack
+  args:
+  - create-builder
+  - --builder-config
+  - builder/builder.toml
+  - --publish
+  - gcr.io/${PROJECT_ID}/buildpack-builder${_IMAGE_SUFFIX}
+  waitFor:
+  - base-push
+  - build-push
+  - run-push
+  - preprocess-builder-image

--- a/hack/upload-buildpacks.sh
+++ b/hack/upload-buildpacks.sh
@@ -54,7 +54,7 @@ run_pack(){
 
 # Fill in our gcr.io registry for the builder
 builder_toml=$temp_dir/builder.toml
-sed "s|\$\{REPLACE_WITH_REGISTRY\}|$registry|g" < "$builder_toml" > "$builder_toml.new"
+cat ${builder_toml} | REPLACE_WITH_REGISTRY="${registry}" envsubst  > "${builder_toml}.new"
 
 build_pack
 echo "building builder from $builder_config..."

--- a/hack/upload-buildpacks.sh
+++ b/hack/upload-buildpacks.sh
@@ -54,7 +54,7 @@ run_pack(){
 
 # Fill in our gcr.io registry for the builder
 builder_toml=$temp_dir/builder.toml
-sed "s|REPLACE_WITH_REGISTRY|$registry|g" < "$builder_toml" > "$builder_toml.new"
+sed "s|\$\{REPLACE_WITH_REGISTRY\}|$registry|g" < "$builder_toml" > "$builder_toml.new"
 
 build_pack
 echo "building builder from $builder_config..."


### PR DESCRIPTION
Added three Cloud Build build configurations.

1. `cloudbuild.tools.yaml` - builds images used in other build configs
2. `cloudbuild.yaml` - builds 4 images: base, build, run, and buildpack-builder
3. `cloudbuild.promote.yaml` - useful for promoting bleeding images to stable images

`cloudbuild.yaml` has a parameter `${_IMAGE_SUFFIX}` with a default value of `-edge`. This is useful for implementing a stable/edge reliability strategy.
Likewise, `cloudbuild.promote.yaml` has two parameters `${_FROM_SUFFIX}` and `${_TO_SUFFIX}` with default values `-edge` and ``.

The following triggers could be added:
1. run `cloudbuild.tools.yaml` on commits to `develop`
2. run `cloudbuild.yaml` on commits to `develop`
3. run `cloudbuild.promote.yaml` on commits to `master`